### PR TITLE
Update step01_hello_lambda-stack.ts

### DIFF
--- a/step01_hello_lambda/lib/step01_hello_lambda-stack.ts
+++ b/step01_hello_lambda/lib/step01_hello_lambda-stack.ts
@@ -8,7 +8,7 @@ export class Step01HelloLambdaStack extends cdk.Stack {
 
     // The code that defines your stack goes here
     const hello = new lambda.Function(this, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.fromAsset("lambda"),
       handler: "hello.handler",
     });


### PR DESCRIPTION
if this isn't set to version 14, this error happens

```
Step01HelloLambdaStack: creating CloudFormation changeset...
7:54:37 PM | CREATE_FAILED        | AWS::Lambda::Function | HelloHandler2E4FBA4D
Resource handler returned message: "The runtime parameter of nodejs10.x is no longer supported for c
reating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs14.x) while cr
eating or updating functions. (Service: Lambda, Status Code: 400, Request ID: 393b41b6-f4d3-4c7f-b22
f-eafa88563ff9, Extended Request ID: null)" (RequestToken: e6b7577c-7ce4-73d0-3de9-ee2964a897ec, Han
dlerErrorCode: InvalidRequest)
```